### PR TITLE
Fix erroreous rds icon showing

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -406,7 +406,7 @@ class SDGRadioScreen(Screen, HelpableScreen):
 			if "callsign_uncertain" in rds and self["pi"].getText() != rds["callsign_uncertain"].encode("utf8"):
 				self["pi"].setText(rds["callsign_uncertain"].encode("utf8"))
 
-			if "pi" in rds and not str(rds["pi"]) == "0x0000" or "callsign" in rds or "callsign_uncertain" in rds or "pi" in rds and str(rds["pi"]) == "0x0000" or "partial_ps" in rds and str(rds["pi"]) == "0x0000":
+			if "pi" in rds and not str(rds["pi"]) == "0x0000" or "callsign" in rds or "callsign_uncertain" in rds or "ps" in rds and str(rds["pi"]) == "0x0000" or "partial_ps" in rds and str(rds["pi"]) == "0x0000":
 				self["rds_icon"].show()
 
 			if "programType" in rds:


### PR DESCRIPTION
Fix erroreous rds icon showing, when pi is falsely reported as 0000 and there is no rds transmission.